### PR TITLE
PXCHARTJS-5 output nonce attrib for supported preside versions

### DIFF
--- a/views/charts/_chart.cfm
+++ b/views/charts/_chart.cfm
@@ -19,7 +19,7 @@
 		<canvas id="#id#" class="chart-canvas"></canvas>
 	</div>
 
-	<script>
+	<script nonce="#event?.getRequestNonce()#">
 		var #id#
 		  , #id#_config = #config#
 		  , #id#_init   = function() {


### PR DESCRIPTION
This helps with Content-Security-Policy where inline scripts can be properly locked down by specifying request nonce to be trusted.
 